### PR TITLE
Makes the privacy and terms links work in footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -52,10 +52,10 @@ export const Footer = () => {
                 </a>
               </div>
 
-              <a style={{ marginLeft: '0.5rem' }} href={'about/terms'}>
+              <a style={{ marginLeft: '0.5rem' }} href={'en/about/terms'}>
                 Terms
               </a>
-              <a style={{ marginLeft: '1.5rem' }} href={'about/privacy'}>
+              <a style={{ marginLeft: '1.5rem' }} href={'en/about/privacy'}>
                 Privacy
               </a>
             </div>


### PR DESCRIPTION
Makes the privacy and terms links work in footer because the current links redirect to the homepage